### PR TITLE
Explicitly set `RedirectView.permanent`

### DIFF
--- a/loginurl/urls.py
+++ b/loginurl/urls.py
@@ -7,5 +7,8 @@ from loginurl.views import cleanup, login
 urlpatterns = patterns('',
     (r'^cleanup/$', cleanup),
     (r'^(?P<key>[0-9A-Za-z]+-[a-z0-9-]+)/$', login), 
-    url(r'^$', RedirectView.as_view(url=settings.LOGIN_URL), name='loginurl-index'),
+    url(r'^$', name='loginurl-index', view=RedirectView.as_view(
+        permanent=True,
+        url=settings.LOGIN_URL,
+    )),
 )


### PR DESCRIPTION
Prevent `RemovedInDjango19Warning` in Django 1.8:

```
.../django-loginurl/loginurl/urls.py:10: RemovedInDjango19Warning:
Default value of 'RedirectView.permanent' will change from True to False in Django 1.9.
Set an explicit value to silence this warning.
  url(r'^$', RedirectView.as_view(url=settings.LOGIN_URL), name='loginurl-index'),
```